### PR TITLE
Use tf2 to transform frame in auto aim task

### DIFF
--- a/rmoss_auto_aim/CMakeLists.txt
+++ b/rmoss_auto_aim/CMakeLists.txt
@@ -17,8 +17,9 @@ find_package(rmoss_util REQUIRED)
 find_package(rmoss_cam REQUIRED)
 find_package(rmoss_projectile_motion REQUIRED)
 find_package(OpenCV REQUIRED)
-find_package(eigen3_cmake_module REQUIRED)
-find_package(Eigen3 REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 # Include
 include_directories(include)
@@ -36,8 +37,9 @@ set(dependencies
   rmoss_cam
   rmoss_projectile_motion
   OpenCV
-  Eigen3
-  eigen3_cmake_module
+  geometry_msgs
+  tf2_geometry_msgs
+  tf2_ros
 )
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
 

--- a/rmoss_auto_aim/config/simple_auto_aim_params.yaml
+++ b/rmoss_auto_aim/config/simple_auto_aim_params.yaml
@@ -1,6 +1,6 @@
 simple_auto_aim:
     ros__parameters:
         debug: True
-        robot_color: "red"
+        target_color: "blue"
         camera_name: "front_camera"
-        auto_start: True
+        autostart: True

--- a/rmoss_auto_aim/include/rmoss_auto_aim/simple_auto_aim_algo.hpp
+++ b/rmoss_auto_aim/include/rmoss_auto_aim/simple_auto_aim_algo.hpp
@@ -36,10 +36,10 @@ typedef struct _ArmorTarget
 class SimpleAutoAimAlgo
 {
 public:
-  SimpleAutoAimAlgo(std::vector<double> camera_intrinsic,
-    std::vector<double> camera_distortion);
+  SimpleAutoAimAlgo();
 
 public:
+  void set_camera_info(std::vector<double> camera_intrinsic, std::vector<double> camera_distortion);
   void set_target_color(bool is_red);
   int process(const cv::Mat &img, float current_pitch);
   ArmorTarget getTarget();
@@ -55,7 +55,7 @@ private:
   // 最终目标
   ArmorTarget mTarget;
   // 其他参数
-  bool mIsTrack;
+  bool mIsTrack{false};
   cv::Point2f mLastPoint2;
   cv::Point3f mLastPoint3;
 };

--- a/rmoss_auto_aim/include/rmoss_auto_aim/simple_auto_aim_node.hpp
+++ b/rmoss_auto_aim/include/rmoss_auto_aim/simple_auto_aim_node.hpp
@@ -15,14 +15,18 @@
 #ifndef RMOSS_AUTO_AIM__SIMPLE_AUTO_AIM_NODE_HPP_
 #define RMOSS_AUTO_AIM__SIMPLE_AUTO_AIM_NODE_HPP_
 
-#include <rclcpp/rclcpp.hpp>
 #include <opencv2/opencv.hpp>
-#include <Eigen/Geometry>
+
+#include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_broadcaster.h"
+#include "tf2_ros/transform_listener.h"
 
 #include "rmoss_cam/cam_client.hpp"
 #include "rmoss_auto_aim/simple_auto_aim_algo.hpp"
 #include "rmoss_projectile_motion/gimbal_transform_tool.hpp"
 
+#include "sensor_msgs/msg/image.hpp"
 #include "rmoss_interfaces/msg/gimbal.hpp"
 #include "rmoss_interfaces/msg/gimbal_cmd.hpp"
 #include "rmoss_interfaces/msg/shoot_cmd.hpp"
@@ -44,13 +48,11 @@ private:
   void init();
   void process_image(const cv::Mat & img, const rclcpp::Time & stamp);
   void set_color(bool is_red);
-  // for task manager
   rmoss_util::TaskStatus get_task_status_cb();
   bool control_task_cb(rmoss_util::TaskCmd cmd);
 
 private:
   rclcpp::Node::SharedPtr node_;
-  rclcpp::TimerBase::SharedPtr init_timer_;
   // 相机客户端
   std::shared_ptr<rmoss_cam::CamClient> cam_client_;
   // 自瞄算法类
@@ -63,17 +65,19 @@ private:
   rclcpp::Publisher<rmoss_interfaces::msg::ShootCmd>::SharedPtr shoot_cmd_pub_;
   rclcpp::Subscription<rmoss_interfaces::msg::Gimbal>::SharedPtr gimbal_state_sub_;
   rclcpp::Service<rmoss_interfaces::srv::SetColor>::SharedPtr set_color_srv_;
+  // tf and message filter
+  rclcpp::TimerBase::SharedPtr init_timer_;
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   // data
   std::string camera_name_;
   std::string target_color_{"red"};
   bool debug_{false};
   bool run_flag_{false};
-  // 假设相机安装在枪管/云台上，相机到云台的坐标变换 T_{gimbal_camera}
-  Eigen::Isometry3d trans_gc_; 
   // tmp data
   bool gimbal_ctrl_flag_{true};
   bool shoot_ctrl_flag_{true};
-  float current_pitch_{0};
 };
 }  // namespace rmoss_auto_aim
 

--- a/rmoss_auto_aim/include/rmoss_auto_aim/simple_auto_aim_node.hpp
+++ b/rmoss_auto_aim/include/rmoss_auto_aim/simple_auto_aim_node.hpp
@@ -75,6 +75,7 @@ private:
   std::string target_color_{"red"};
   bool debug_{false};
   bool run_flag_{false};
+  tf2::Duration transform_tolerance_;
   // tmp data
   bool gimbal_ctrl_flag_{true};
   bool shoot_ctrl_flag_{true};

--- a/rmoss_auto_aim/include/rmoss_auto_aim/simple_auto_aim_node.hpp
+++ b/rmoss_auto_aim/include/rmoss_auto_aim/simple_auto_aim_node.hpp
@@ -41,17 +41,16 @@ public:
   }
 
 private:
+  void init();
   void process_image(const cv::Mat & img, const rclcpp::Time & stamp);
-  bool set_color_cb(
-    const rmoss_interfaces::srv::SetColor::Request::SharedPtr request,
-    rmoss_interfaces::srv::SetColor::Response::SharedPtr response);
-  void gimbal_state_cb(const rmoss_interfaces::msg::Gimbal::SharedPtr msg);
+  void set_color(bool is_red);
   // for task manager
   rmoss_util::TaskStatus get_task_status_cb();
   bool control_task_cb(rmoss_util::TaskCmd cmd);
 
 private:
   rclcpp::Node::SharedPtr node_;
+  rclcpp::TimerBase::SharedPtr init_timer_;
   // 相机客户端
   std::shared_ptr<rmoss_cam::CamClient> cam_client_;
   // 自瞄算法类
@@ -65,6 +64,8 @@ private:
   rclcpp::Subscription<rmoss_interfaces::msg::Gimbal>::SharedPtr gimbal_state_sub_;
   rclcpp::Service<rmoss_interfaces::srv::SetColor>::SharedPtr set_color_srv_;
   // data
+  std::string camera_name_;
+  std::string target_color_{"red"};
   bool debug_{false};
   bool run_flag_{false};
   // 假设相机安装在枪管/云台上，相机到云台的坐标变换 T_{gimbal_camera}

--- a/rmoss_auto_aim/src/armor_detector_test_main.cpp
+++ b/rmoss_auto_aim/src/armor_detector_test_main.cpp
@@ -53,8 +53,10 @@ int main(int argc, char * argv[])
     }
   };
   // create cam client
-  auto cam_client = std::make_shared<rmoss_cam::CamClient>(
-    node, camera_name, process_image_fn, false);
+  auto cam_client = std::make_shared<rmoss_cam::CamClient>(node);
+  cam_client->set_camera_name(camera_name);
+  cam_client->set_camera_callback(process_image_fn);
+  cam_client->connect();
   // spin
   rclcpp::spin(node);
   rclcpp::shutdown();

--- a/rmoss_auto_aim/src/auto_aim_algo/simple_auto_aim_algo.cpp
+++ b/rmoss_auto_aim/src/auto_aim_algo/simple_auto_aim_algo.cpp
@@ -17,11 +17,8 @@ using namespace std;
 using namespace cv;
 using namespace rmoss_auto_aim;
 
-SimpleAutoAimAlgo::SimpleAutoAimAlgo(
-  std::vector<double> camera_intrinsic,
-  std::vector<double> camera_distortion)
+SimpleAutoAimAlgo::SimpleAutoAimAlgo()
 {
-  mIsTrack = false;
   //初始化装甲板参数
   float realWidth, realHeight, half_x, half_y;
   realHeight = 6.3;
@@ -38,10 +35,15 @@ SimpleAutoAimAlgo::SimpleAutoAimAlgo(
   mBigArmorPoints.emplace_back(-half_x, half_y, 0);
   mBigArmorPoints.emplace_back(-half_x, -half_y, 0);
   mBigArmorPoints.emplace_back(half_x, -half_y, 0);
-  //初始化工具类
-  armor_detector_.set_target_color(true);
+}
+
+void SimpleAutoAimAlgo::set_camera_info(
+  std::vector<double> camera_intrinsic,
+  std::vector<double> camera_distortion)
+{
   mono_location_tool_.set_camera_info(camera_intrinsic, camera_distortion);
 }
+
 
 int SimpleAutoAimAlgo::process(const cv::Mat &img, float current_pitch)
 {

--- a/rmoss_auto_aim/src/simple_auto_aim_node.cpp
+++ b/rmoss_auto_aim/src/simple_auto_aim_node.cpp
@@ -26,15 +26,19 @@ SimpleAutoAimNode::SimpleAutoAimNode(const rclcpp::NodeOptions & options)
 {
   node_ = std::make_shared<rclcpp::Node>("simple_auto_aim", options);
   bool autostart = false;
+  double transform_tolerance_sec;
   // parameters
   node_->declare_parameter("target_color", target_color_);
   node_->declare_parameter("debug", debug_);
   node_->declare_parameter("camera_name", camera_name_);
   node_->declare_parameter("autostart", autostart);
+  node_->declare_parameter("transform_tolerance", transform_tolerance_sec);
   node_->get_parameter("target_color", target_color_);
   node_->get_parameter("debug", debug_);
   node_->get_parameter("camera_name", camera_name_);
   node_->get_parameter("autostart", autostart);
+  node_->get_parameter("transform_tolerance", transform_tolerance_sec);
+  transform_tolerance_ = tf2::durationFromSec(transform_tolerance_sec);
   rmoss_util::set_debug(debug_);
   // create pub,sub,srv
   using namespace std::placeholders;
@@ -117,7 +121,7 @@ void SimpleAutoAimNode::process_image(const cv::Mat & img, const rclcpp::Time &s
   target_in_camera.point.y = target.postion.y;
   target_in_camera.point.z = target.postion.z;
   try{
-    tf_buffer_->transform(target_in_camera, target_in_home, "gimbal_home", 10ms);
+    tf_buffer_->transform(target_in_camera, target_in_home, "gimbal_home", transform_tolerance_);
   } catch (tf2::TransformException & e) {
     RCLCPP_ERROR(
       node_->get_logger(), "%s_optical transforms failed: (%s)", camera_name_.c_str(), e.what());


### PR DESCRIPTION
解决 https://github.com/robomaster-oss/rmoss_contrib/issues/2

采用tf2作为自瞄任务中的坐标变换工具，无需进行手动变换，并有利于后续自瞄功能扩展。
* 采用tf2消息订阅，无需订阅当前云台角度。
* tf2参考系：`base_link`->`gimbal_yaw`->`gimbal_pitch`->`camera`->`camera_optical`->`target`(识别到的目标装甲板)：其中`gimbal_yaw`和`gimbal_pitch`根据云台角度实时更新维护，该维护由`rmoss_base`实现或其它第三方包实现，`rmoss_auto_aim`直接使用维护好的坐标变换关系。

* 该PR依赖于 https://github.com/robomaster-oss/rmoss_core/pull/16